### PR TITLE
Revert "ipv6: Don't reduce hop limit for an interface"

### DIFF
--- a/net/ipv6/ndisc.c
+++ b/net/ipv6/ndisc.c
@@ -1266,14 +1266,7 @@ static void ndisc_router_discovery(struct sk_buff *skb)
 	if (rt)
 		rt6_set_expires(rt, jiffies + (HZ * lifetime));
 	if (ra_msg->icmph.icmp6_hop_limit) {
-		/* Only set hop_limit on the interface if it is higher than
-		 * the current hop_limit.
-		 */
-		if (in6_dev->cnf.hop_limit < ra_msg->icmph.icmp6_hop_limit) {
-			in6_dev->cnf.hop_limit = ra_msg->icmph.icmp6_hop_limit;
-		} else {
-			ND_PRINTK2(KERN_WARNING "RA: Got route advertisement with lower hop_limit than current\n");
-		}
+		in6_dev->cnf.hop_limit = ra_msg->icmph.icmp6_hop_limit;
 		if (rt)
 			dst_metric_set(&rt->dst, RTAX_HOPLIMIT,
 				       ra_msg->icmph.icmp6_hop_limit);


### PR DESCRIPTION
This reverts commit 08dc433389b833b44cd05bc8fe4dc1e89b9a75dd.
